### PR TITLE
allow null in an optionalString enum

### DIFF
--- a/src/Type.ts
+++ b/src/Type.ts
@@ -47,7 +47,7 @@ export const Type = {
       type: String,
     } as unknown) as EnumOrString<T>;
   },
-  optionalString: <T extends ReadonlyArray<string>>(
+  optionalString: <T extends ReadonlyArray<string | null>>(
     options: Omit<SchemaTypeOpts<string>, 'enum'> & {
       enum?: T;
     } = {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,8 @@ export type Extract<T> = T extends { definition: infer U } ? U : never;
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export type EnumOrString<
-  T extends ReadonlyArray<string> | undefined
-> = T extends ReadonlyArray<string> ? T[number] : undefined;
+  T extends ReadonlyArray<string | null> | undefined
+> = T extends ReadonlyArray<string | null> ? T[number] : undefined;
 
 type ExtractOptions<T> = T extends { options: infer U } ? U : never;
 type DisabledIdOption = { _id: false };


### PR DESCRIPTION
It's sometimes useful to have an enum in an optional type.

Right now, enum support is great for strings

```
// letters is "a" | "b" | "c"
letters: Type.string({enum: ["a", "b", "c"] as const}) 
```

but if I have an optional enum, I can't specify `null`:

```
// Type 'null' is not assignable to type 'string'
optionalLetters: Type.optionalString({enum: ["a", "b", "c", null] as const}) 
```

If I don't specify `null` in the enum, though, and save a document with that field missing, mongoose will fail validation.

This PR just broadens the enum type for Type.optionalString to allow `null` in the enums.

Now:

```
// letters is "a" | "b" | "c" | null | undefined
optionalLetters: Type.optionalString({enum: ["a", "b", "c", null] as const}) 
```

The other possible solution is to automatically add `null` to enums of type optionalString, since I can't think of a situation during which you would want an optionalString without `null` in the enum. However ts-mongoose probably shouldn't silently modify runtime behavior. 

Thanks for a clever package!